### PR TITLE
Add kustomize 5.2.1

### DIFF
--- a/kustomize/private/tools/kustomize/toolchain.bzl
+++ b/kustomize/private/tools/kustomize/toolchain.bzl
@@ -3,6 +3,14 @@
 visibility("public")
 
 _TOOLS_BY_RELEASE = {
+    "v5.2.1": {
+        struct(os = "darwin", arch = "amd64"): "b7aba749da75d33e6fea49a5098747d379abc45583ff5cd16e2356127a396549",
+        struct(os = "darwin", arch = "arm64"): "f6a5f3cffd45bac585a0c80b5ed855c2b72d932a1d6e8e7c87aae3be4eba5750",
+        struct(os = "linux", arch = "amd64"): "88346543206b889f9287c0b92c70708040ecd5aad54dd33019c4d6579cd24de8",
+        struct(os = "linux", arch = "arm64"): "5566f7badece5a72d42075d8dffa6296a228966dd6ac2390de7afbb9675c3aaa",
+        struct(os = "windows", arch = "amd64"): "870ccb282cb3404c471a7f270299ae0cf1310f354822b8c0a626f1edd0b3dcff",
+        struct(os = "windows", arch = "arm64"): "ef5b2953cf792fa0118429c090113f697aca1810f6d5015838ad0917351ade9d",
+    },
     "v5.1.0": {
         struct(os = "darwin", arch = "amd64"): "08664a17820138a68b7cbe302b1b63f4ec19c6e0838385f789ee0470f026ba25",
         # NB: There is no Darwin build available for the ARM64 architecture.
@@ -37,7 +45,7 @@ _TOOLS_BY_RELEASE = {
     },
 }
 
-_DEFAULT_TOOL_VERSION = "v5.1.0"
+_DEFAULT_TOOL_VERSION = "v5.2.1"
 
 def known_release_versions():
     return _TOOLS_BY_RELEASE.keys()


### PR DESCRIPTION
# What

This Adds kustomize 5.2.1 releases to the toolchains https://github.com/kubernetes-sigs/kustomize/releases/tag/kustomize%2Fv5.2.1

It seems that the kustomize folks have changed the `windows` builds to be `zip` files instead of `tar.gz` is that going to break anything on this newer version?

I also need this pr because the latest version 5.1.0 available in the toolchains does not include arm64 macos, which I am now using

```
INFO: ToolchainResolution:   Type @rules_kustomize~0.3.5//tools/kustomize:toolchain_type: target platform @local_config_platform//:host: No toolchains found.
ERROR: /Users/bnobuhara/src/bt/infra-apps/examples/config/kubernetes/BUILD.bazel:68:21: While resolving toolchains for target //examples/config/kubernetes:kubernetes_upstream_kustomized_resources: No matching toolchains found for types @rules_kustomize~0.3.5//tools/kustomize:toolchain_type.
To debug, rerun with --toolchain_resolution_debug='@rules_kustomize~0.3.5//tools/kustomize:toolchain_type'
If platforms or toolchains are a new concept for you, we'd encourage reading https://bazel.build/concepts/platforms-intro.
```

```
$ bazel query --output=build @local_config_platform//:host
# /private/var/tmp/_bazel_bnobuhara/d28b21fbdd8288426ba7b73c2dda9527/external/local_config_platform/BUILD.bazel:4:9
platform(
  name = "host",
  constraint_values = ["@platforms~0.0.6//cpu:aarch64", "@platforms~0.0.6//os:osx"],
)
```

```
$ sha256sum ~/Downloads/kustomize_v5.2.1_*
b7aba749da75d33e6fea49a5098747d379abc45583ff5cd16e2356127a396549  /Users/bnobuhara/Downloads/kustomize_v5.2.1_darwin_amd64.tar.gz
f6a5f3cffd45bac585a0c80b5ed855c2b72d932a1d6e8e7c87aae3be4eba5750  /Users/bnobuhara/Downloads/kustomize_v5.2.1_darwin_arm64.tar.gz
88346543206b889f9287c0b92c70708040ecd5aad54dd33019c4d6579cd24de8  /Users/bnobuhara/Downloads/kustomize_v5.2.1_linux_amd64.tar.gz
5566f7badece5a72d42075d8dffa6296a228966dd6ac2390de7afbb9675c3aaa  /Users/bnobuhara/Downloads/kustomize_v5.2.1_linux_arm64.tar.gz
870ccb282cb3404c471a7f270299ae0cf1310f354822b8c0a626f1edd0b3dcff  /Users/bnobuhara/Downloads/kustomize_v5.2.1_windows_amd64.zip
ef5b2953cf792fa0118429c090113f697aca1810f6d5015838ad0917351ade9d  /Users/bnobuhara/Downloads/kustomize_v5.2.1_windows_arm64.zip
```