### PR TITLE
Fix code block for `kustomized_resources`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ By default, the kustomization_ rule assumes the :file:`kustomization` file is na
 This "base" target we've defined doesn't produce any artifacts. It prepares the recipe for building artifacts, in the same way that a :term:`kustomization`'s files are inert input for the :tool:`kustomize` tool. When we'd like to build the :term:`kustomization` using particular options—as we would by invoking :command:`kustomize build`—we define another target in a :file:`BUILD.bazel` file. Here we'll add to the same Bazel package, this time using the kustomized_resources_ rule.
 
 .. code:: bazel
+
     load(
         "@rules_kustomize//kustomize:kustomize.bzl",
         "kustomized_resources",


### PR DESCRIPTION
Hey there! I noticed while reading through the README that the code block for `kustomized_resources` wasn't rendering. So I popped up this quick PR to fix it.

Feel free to take it, ignore it, close it, whatever you'd prefer.